### PR TITLE
Add docs and sample data directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ File/Folder	Description
 openapi.yaml	OpenAPI 3.1.0 specification defining Sigmund’s API endpoints.
 ai-plugin.json	Manifest file for configuring the Custom Actions with OpenAI.
 README.md	Documentation for the repository.
-specs/	Placeholder for future endpoint specifications.
-assets/	Static files, JSON data, and other supporting resources.
+specs/	Additional OpenAPI snippets and endpoint documentation.
+assets/	Example data and other supporting resources.
 
 ## 🚀 Getting Started
 
 To integrate Sigmund with OpenAI Custom Actions:
 
-Host the openapi.yaml and ai-plugin.json files publicly (e.g., using GitHub raw links).
-In the OpenAI Custom GPT Actions interface, upload or link to your manifest file.
-Ensure all APIs (static or dynamic) are reachable by the GPT model.
+- Host the openapi.yaml and ai-plugin.json files publicly (e.g., using GitHub raw links).
+- In the OpenAI Custom GPT Actions interface, upload or link to your manifest file.
+- Ensure all APIs (static or dynamic) are reachable by the GPT model.
+- Explore the `specs/` and `assets/` folders for example endpoints and data.
 
 ## ✨ Future Enhancements
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,7 @@
+# Assets Directory
+
+Static files and example data used by Sigmund.
+
+- `dream_symbols.json` – A small sample of dream symbols and their Freudian interpretations.
+
+More assets can be placed here as the project expands.

--- a/assets/dream_symbols.json
+++ b/assets/dream_symbols.json
@@ -1,0 +1,5 @@
+{
+  "snake": "A symbol of repressed desire or fear of betrayal.",
+  "falling": "Represents anxiety or a loss of control.",
+  "mirror": "Indicates self-reflection or identity concerns."
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,3 +59,28 @@ paths:
                     items:
                       type: string
                     description: List of user associations related to the dream symbol
+  /mood:
+    post:
+      operationId: logMood
+      summary: Record the user's current mood for analysis.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mood:
+                  type: string
+                  description: The user's self-reported mood.
+      responses:
+        "200":
+          description: Mood logged successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,7 @@
+# Specs Directory
+
+This folder contains OpenAPI snippets and extended documentation for future endpoints.
+
+- `mood-tracking.yaml` – Sample specification for a mood-tracking endpoint.
+
+Add additional specs here as the project grows.

--- a/specs/mood-tracking.yaml
+++ b/specs/mood-tracking.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+info:
+  title: Mood Tracking API
+  description: Provides endpoints for tracking user mood over time.
+  version: 0.1.0
+paths:
+  /mood:
+    post:
+      summary: Record the user's current mood.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mood:
+                  type: string
+                  description: User's self-reported mood.
+      responses:
+        "200":
+          description: A confirmation message.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+


### PR DESCRIPTION
## Summary
- add `assets/` and `specs/` directories referenced in README
- include sample `dream_symbols.json` and a mood-tracking OpenAPI snippet
- expand `openapi.yaml` with a `/mood` endpoint example
- update README with new instructions and directory descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840217acc408327ba5b1225a0baba46